### PR TITLE
Fix katakana linebreak

### DIFF
--- a/autoload/autofmt/uax14.vim
+++ b/autoload/autofmt/uax14.vim
@@ -1,6 +1,14 @@
 " Maintainer:   Yukihiro Nakadaira <yukihiro.nakadaira@gmail.com>
 " License:      This file is placed in the public domain.
-" Last Change:  2013-03-07
+" Last Change:  2016-11-24
+"
+" Options:
+"
+"   autofmt_strict_japanese_linebreak   number (default: 1)
+"
+"     If set to 1, line break before KATAKANA-HIRAGANA PROLONGED SOUND MARK
+"     and small kana letters are disallowed.  If set to 0, they are allowed.
+"
 
 let s:cpo_save = &cpo
 set cpo&vim
@@ -18,6 +26,7 @@ let s:compat = autofmt#compat#import()
 let s:lib = {}
 call extend(s:lib, s:compat)
 
+let s:lib.autofmt_strict_japanese_linebreak = 1
 let s:lib.uni = autofmt#unicode#import()
 
 function! s:lib.check_boundary(lst, i)
@@ -29,6 +38,8 @@ function! s:lib.check_boundary(lst, i)
   let after = self.uni.prop_line_break(lst[i].c)
   if after == "AI"    " Ambiguous (Alphabetic or Ideograph)
     let after = (lst[i].w == 1) ? "AL" : "ID"
+  elseif after == "CJ"  " Conditional Japanese Starter
+    let after = self.get_opt("autofmt_strict_japanese_linebreak") ? "NS" : "ID"
   endif
 
   let j = i - 1
@@ -39,6 +50,8 @@ function! s:lib.check_boundary(lst, i)
   let before = self.uni.prop_line_break(lst[j].c)
   if before == "AI"   " Ambiguous (Alphabetic or Ideograph)
     let before = (lst[j].w == 1) ? "AL" : "ID"
+  elseif before == "CJ" " Conditional Japanese Starter
+    let before = self.get_opt("autofmt_strict_japanese_linebreak") ? "NS" : "ID"
   endif
 
   let brk = self.uni.uax14_pair_table(before, after)

--- a/autoload/autofmt/unicode.vim
+++ b/autoload/autofmt/unicode.vim
@@ -1,6 +1,6 @@
 " Maintainer:   Yukihiro Nakadaira <yukihiro.nakadaira@gmail.com>
 " License:      This file is placed in the public domain.
-" Last Change:  2014-08-28
+" Last Change:  2016-11-24
 
 if &encoding != "utf-8" && !has("iconv")
   " Use echomsg because echoerr is not displayed in formatexpr context.
@@ -95,7 +95,7 @@ endfunction
 
 function s:lib.uax14_pair_table(before, after)
   " these are not handled in the pair tables
-  let not_in_table = '\vAI|BK|CB|CR|LF|NL|SA|SG|SP|XX'
+  let not_in_table = '\vAI|BK|CB|CJ|CR|LF|NL|SA|SG|SP|XX'
   if a:before =~ not_in_table || a:after =~ not_in_table
     return self.PROHIBITED_BRK
   else

--- a/memo.txt
+++ b/memo.txt
@@ -8,6 +8,12 @@ http://unicode.org/reports/tr14/
 Word wrap - Wikipedia
 http://en.wikipedia.org/wiki/Word_wrap
 
+Requirements for Japanese Text Layout
+https://www.w3.org/TR/jlreq/
+日本語組版処理の要件
+https://www.w3.org/TR/jlreq/ja/
+Mainly based on JIS X 4051
+
 JISC 日本工業標準調査会
 http://www.jisc.go.jp/
 JIS X 4051 - Wikipedia


### PR DESCRIPTION
#5 に対する修正です。

`CJ`プロパティーを解釈し、`g:autofmt_strict_japanese_linebreak` の値によって動作を変えるようにしてみました。
`g:autofmt_strict_japanese_linebreak` が 1 ならば従来の動作で、長音記号・拗音は禁則処理の対象となります。0 ならば対象となりません。