### PR TITLE
Insert a header automatically

### DIFF
--- a/tools/unicode.vim
+++ b/tools/unicode.vim
@@ -57,9 +57,17 @@ function! s:main()
   else
     edit LineBreak.txt
   endif
+  let header = getline(1, 2)
   let linebreak = s:parse_prop(getline(1, '$'))
 
   enew
+
+  if header[0] =~# '^# LineBreak-.*\.txt'
+    $put ='\"' . header[0][1:]
+  endif
+  if header[1] =~# '^# Date: '
+    $put ='\"' . header[1][1:]
+  endif
 
   " MEMO: line length is optimized for Vim's reading buffer size.
   $put ='let s:tmp = []'


### PR DESCRIPTION
`tool/unicode.vim` でデータベースを作成する際に、以下のようなヘッダーを自動生成するようにしました。

```
" LineBreak-7.0.0.txt
" Date: 2014-02-28, 23:15:00 GMT [KW, LI]
```

関連: #7