### PR TITLE
Use LF for doc/tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+doc/tags	text eol=lf


### PR DESCRIPTION
Always use the unix file format for doc/tags even on Windows (with
`core.autocrlf=true`).

Even with the Windows version of Vim, the `:helptags` command creates
tags files with the unix file format.
To avoid unnecessary changes, doc/tags should be checked out with the
unix file format.

Related: #16, https://github.com/vim-jp/vimdoc-ja/pull/269